### PR TITLE
Igmp burst detection + refactoring

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,5 +8,7 @@ RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 VOLUME ["/App"]
 WORKDIR /App
 
+ENV RUNNING_IN_DOCKER Yes
+
 ENTRYPOINT ["python3", "-m", "pytest", "-o", "log_cli=True"]
 

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -31,3 +31,13 @@ MGROUP_2 = "239.255.0.2"  # sACN universe 2
 # registrations are handled. Therefore it is recommended that end devices stay well below
 # such a limit with the number of multicast addresses they would like to register
 IGMP_MEMBERSHIP_REPORT_THRESHOLD = 256
+
+# It is possible to test the contents of a PCAP file instead of running 'live'
+# against a device.
+# To do this, filter 1 IGMP query interval from the capture. Meaning: the capture
+# should only contain 1 IGMP query and the IGMP reports on this query.
+# If it is IGMPv3, make sure to enable IGMPV3_SUPPORT above.
+# Set the following parameter to the path to the pcap file
+# Run the test by appending `src/test_pcap.py` to the run command
+#PCAP_FILE = "output/my_capture.pcapng"
+PCAP_FILE = False

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -24,3 +24,10 @@ MGROUP_1 = "239.255.0.1"  # sACN universe 1
 # If using sACN, universe 2 corresponds with multicast address 239.255.0.2
 # MGROUP_2 is only used in manual tests
 MGROUP_2 = "239.255.0.2"  # sACN universe 2
+
+# When a single device transmits more than this amount of IGMP membership reports,
+# The test will fail. Sending too many membership reports can overwhelm the networking
+# equipment and most networking equipment has a (large) limit to the number of multicast
+# registrations are handled. Therefore it is recommended that end devices stay well below
+# such a limit with the number of multicast addresses they would like to register
+IGMP_MEMBERSHIP_REPORT_THRESHOLD = 256

--- a/src/lib/packet.py
+++ b/src/lib/packet.py
@@ -93,9 +93,11 @@ def get_v2_leaves(capture):
 def get_v3_membership_queries(capture):
     packets = []
     for pkt in scapy.utils.PcapReader(capture):
-        if pkt.haslayer(IGMPv3mq):
+        if pkt.haslayer(IGMPv3) and pkt.haslayer(IGMPv3mq):
             ip_data = pkt[IP]
             igmp_data = pkt[IGMPv3]
+            if igmp_data.type != IGMPMessageType.MEMBERSHIP_QUERY.value:
+                continue
             igmp_mq_data = pkt[IGMPv3mq]
             assert igmp_data.resv == 0, 'The reserved field should be set to 0'
             packets.append({
@@ -111,8 +113,11 @@ def get_v3_membership_queries(capture):
 def get_v3_membership_reports(capture):
     packets = []
     for pkt in scapy.utils.PcapReader(capture):
-        if pkt.haslayer(IGMPv3mr):
+        if pkt.haslayer(IGMPv3) and pkt.haslayer(IGMPv3mr):
             ip_data = pkt[IP]
+            igmp_data = pkt[IGMPv3]
+            if igmp_data.type != IGMPMessageType.V3_MEMBERSHIP_REPORT.value:
+                continue
             igmp_data = pkt[IGMPv3mr]
             packets.append({
                 "src": ip_data.src,

--- a/src/lib/packet.py
+++ b/src/lib/packet.py
@@ -72,7 +72,8 @@ def get_igmp_v2_packets(capture, type):
                     "src": ip_data.src,
                     "dst": ip_data.dst,
                     "gaddr": igmp_data.gaddr,
-                    "time": pkt.time
+                    "time": pkt.time,
+                    "mrcode": igmp_data.mrcode
                     })
     return packets
 
@@ -94,13 +95,15 @@ def get_v3_membership_queries(capture):
     for pkt in scapy.utils.PcapReader(capture):
         if pkt.haslayer(IGMPv3mq):
             ip_data = pkt[IP]
-            igmp_data = pkt[IGMPv3mq]
+            igmp_data = pkt[IGMPv3]
+            igmp_mq_data = pkt[IGMPv3mq]
             assert igmp_data.resv == 0, 'The reserved field should be set to 0'
             packets.append({
                 "src": ip_data.src,
                 "dst": ip_data.dst,
                 "time": pkt.time,
-                "srcaddrs": igmp_data.srcaddrs
+                "srcaddrs": igmp_mq_data.srcaddrs,
+                "mrcode": igmp_data.mrcode
                 })
     return packets
 

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -2,6 +2,7 @@ from configuration import IFACE
 import psutil
 import socket
 import os
+import sys
 
 
 def check_interface_up(expected=True):

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -19,7 +19,6 @@ def check_interface_up(expected=True):
 
 def validate_igmpv2_reports(
         pcap_file,
-        source_ip="2.0.0.1",
         gaddr="0.0.0.0"):
     print("Check capture for V2 membership report")
     membership_reports = packet.get_v2_membership_reports(pcap_file)

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -1,19 +1,9 @@
 from configuration import IFACE
 import psutil
 import socket
-import os
-import sys
 
 
 def check_interface_up(expected=True):
     interface_addrs = psutil.net_if_addrs().get(IFACE) or []
     up = socket.AF_INET in [snicaddr.family for snicaddr in interface_addrs]
     assert up == expected, f'Interface {IFACE} is not in the expected link state (up = {expected})'
-
-
-def set_interface_link(up: bool):
-    assert sys.platform.startswith('linux'), 'This function uses the `ip` command and only works on Linux systems'
-    if up:
-        os.system(f"ip link set dev {IFACE} up")
-    else:
-        os.system(f"ip link set dev {IFACE} down")

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -1,7 +1,11 @@
-from configuration import IFACE
+from configuration import IFACE, MGROUP_1, IGMP_MEMBERSHIP_REPORT_THRESHOLD
+import lib.packet as packet
 import psutil
 import socket
 import os
+import warnings
+import struct
+from statistics import median
 
 
 def check_interface_up(expected=True):
@@ -11,3 +15,166 @@ def check_interface_up(expected=True):
     interface_addrs = psutil.net_if_addrs().get(IFACE) or []
     up = socket.AF_INET in [snicaddr.family for snicaddr in interface_addrs]
     assert up == expected, f'Interface {IFACE} is not in the expected link state (up = {expected})'
+
+
+def validate_igmpv2_reports(
+        pcap_file,
+        source_ip="2.0.0.1",
+        gaddr="0.0.0.0"):
+    print("Check capture for V2 membership report")
+    membership_reports = packet.get_v2_membership_reports(pcap_file)
+    assert len(membership_reports) > 0, f"Found {len(membership_reports)} IGMPv2 membership " \
+                                        f"reports, expected at least 1"
+    print(membership_reports)
+
+    print("Check that for each membership report, the IP destination address is equal to the group address")
+    gaddrs = []
+    source_ips = {}
+    for report in membership_reports:
+        src = report['src']
+        dst = report['dst']
+        rcv_gaddr = report['gaddr']
+        assert dst == rcv_gaddr, f"Received membership report from {src} where destination " \
+                                 f"address {dst} is not equal to the group address {rcv_gaddr}"
+        assert rcv_gaddr not in gaddrs, f"Received duplicate membership report for {rcv_gaddr}"
+        gaddrs.append(rcv_gaddr)
+        if src in source_ips.keys():
+            source_ips[src] += 1
+        else:
+            source_ips[src] = 1
+
+    if gaddr != "0.0.0.0":
+        assert gaddr in gaddrs, f"No membership report for {gaddr} received"
+        assert len(gaddrs) == 1, f"Received membership report for multiple " \
+                                 f"addresses as a response to the specific " \
+                                 f"query for {gaddr}: {gaddrs}"
+
+    for src, count in source_ips.items():
+        assert count <= IGMP_MEMBERSHIP_REPORT_THRESHOLD, \
+            f"Received {count} membership reports from {src}. " \
+            f"There is a limit to the amount of membership reports network equipment can handle. " \
+            f"Verify that all these multicast addresses are necessary for your application."
+
+        if count > 100:
+            warnings.warn(UserWarning(f"INFO: Received {count} membership reports from {src}. This is allowed, but make sure that all of them are necessary."))
+
+    assert True
+
+
+def validate_igmpv3_reports(pcap_file, gaddr="0.0.0.0"):
+    """Validate IGMPv3 reports
+    This is a helper function to validate if a pcap file contains IGMPv2 or IGMPv3
+    membership reports.
+    """
+    v2_membership_reports = packet.get_v2_membership_reports(pcap_file)
+    v3_membership_reports = packet.get_v3_membership_reports(pcap_file)
+    assert len(v3_membership_reports) > 0 or len(v2_membership_reports) > 0, \
+        "Found no IGMP membership " \
+        "reports, expected at least 1"
+    print(v2_membership_reports)
+    print(v3_membership_reports)
+
+    if len(v3_membership_reports) == 0:
+        warnings.warn(UserWarning("INFO: DUT responded with V2 membership reports to V3 query"))
+
+    print(f"Check that a v3 membership report is received for {MGROUP_1}")
+
+    found_mgroup_1_join = False
+    for report in v2_membership_reports:
+        if report["gaddr"] == MGROUP_1:
+            found_mgroup_1_join = True
+            assert report["gaddr"] == report["dst"], "Membership reports should use the same multicast destination " \
+                                                     "address as the address present in the IGMP payload"
+    for report in v3_membership_reports:
+        assert report["dst"] == "224.0.0.22", "IGMPv3 packets should be addressed to 224.0.0.22"
+        if gaddr != '0.0.0.0':
+            assert len(report["records"]) == 1, 'Specific membership reports are expected to have 1 group record'
+        for record in report["records"]:
+            if record.maddr == MGROUP_1:
+                found_mgroup_1_join = True
+
+    assert found_mgroup_1_join, f"Expected to get an IGMP membership report for multicast group {MGROUP_1}"
+
+    return v2_membership_reports + v3_membership_reports
+
+def validate_reports(query_time, max_response_time, membership_reports):
+    print("Verify for each membership report that it arrived in time")
+    # Add a small tolerance to the maximum response time to take into account
+    # network transit time and timestamp inaccuracy
+    max_resp = max_response_time + 0.1
+    last_resp = query_time
+    elapsed_list = []
+    response_time = None
+    for report in membership_reports:
+        # Calculate that the elapsed time since the query packet is within tolerance
+        elapsed = report["time"] - query_time
+        print(f"Got response in {elapsed} seconds. Max is {max_response_time} seconds")
+        assert elapsed < max_resp, f"Membership report received after {elapsed} seconds, " \
+                                   f"but the maximum is {max_response_time} seconds"
+        # Only track first response for statistic calculations.
+        # Some devices may have lots of responses, this may disturb the result of the statistics
+        if response_time == None:
+            response_time = elapsed
+
+        # Calculate the elapsed time since the previous membership report and verify
+        # That these are not transmitted in a burst
+        elapsed = report["time"] - last_resp
+        last_resp = report["time"]
+        elapsed_list.append(elapsed)
+
+    median_inter_response_time = median(elapsed_list)
+    assert median_inter_response_time > 0.001, \
+        f"The median time between membership responses is {median_inter_response_time}. " \
+        f"This might indicate that responses are transmitted in burst instead of randomly " \
+        f"delaying each and every response. Tranmsitting a lot of IGMP responses in burst may " \
+        f"overload the IGMP querier and cause responses to be dropped, leading to the multicast " \
+        f"registrations being dropped as well."
+
+    assert len(elapsed_list) <= IGMP_MEMBERSHIP_REPORT_THRESHOLD, \
+        f"Received {len(elapsed_list)} membership reports. " \
+        f"There is a limit to the amount of membership reports network equipment can handle. " \
+        f"Verify that all these multicast addresses are necessary for your application."
+
+    return response_time
+
+def validate_igmpv2_packet_spacing(pcap_file):
+    print("Check capture for V2 membership report")
+    membership_reports = packet.get_v2_membership_reports(pcap_file)
+    print(membership_reports)
+    assert len(membership_reports) != 0, f"Found {len(membership_reports)} IGMPv2 membership " \
+                                         f"reports, expected at least 1"
+
+    print("Get membership query timestamp")
+    membership_query = packet.get_v2_membership_queries(pcap_file)
+    print(membership_query)
+    assert len(membership_query) == 1, f"Found {len(membership_reports)} IGMPv2 membership " \
+                                       f"queries, expected exactly 1"
+
+    query_time = membership_query[0]["time"]
+    mrcode = membership_query[0]["mrcode"]
+    max_response_time = mrcode / 10
+    return validate_reports(query_time, max_response_time, membership_reports)
+
+
+def validate_igmpv3_packet_spacing(pcap_file):
+    print("Check capture for V3 membership report")
+    membership_reports = validate_igmpv3_reports(pcap_file)
+
+    print("Get membership query timestamp")
+    membership_query = packet.get_v3_membership_queries(pcap_file)
+    print(membership_query)
+    assert len(membership_query) == 1, f"Found {len(membership_reports)} IGMPv3 membership " \
+                                       f"queries, expected exactly 1"
+
+    print("Verify for each membership report that it arrived in time")
+    query_time = membership_query[0]["time"]
+    mrcode = membership_query[0]["mrcode"]
+    if mrcode < 128:
+        max_response_time = mrcode / 10
+    else:
+        exp = (mrcode & 0x70) > 4  # 0x70 = b'0111 0000'
+        mant = mrcode & 0xF  # 0xF = b'0000 1111'
+        max_response_time = (mant | 0x10) << (exp + 3)
+    return validate_reports(query_time, max_response_time, membership_reports)
+
+

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -1,9 +1,13 @@
 from configuration import IFACE
 import psutil
 import socket
+import os
 
 
 def check_interface_up(expected=True):
+    if os.environ.get('RUNNING_IN_DOCKER', False):
+        # When running inside a Docker container, the interface is always up.
+        return
     interface_addrs = psutil.net_if_addrs().get(IFACE) or []
     up = socket.AF_INET in [snicaddr.family for snicaddr in interface_addrs]
     assert up == expected, f'Interface {IFACE} is not in the expected link state (up = {expected})'

--- a/src/test_igmp.py
+++ b/src/test_igmp.py
@@ -41,7 +41,7 @@ def validate_membership_reports(
     print("Stop capture")
     stop_capture(pcap_file)
 
-    validate_igmpv2_reports(pcap_file, source_ip, gaddr)
+    validate_igmpv2_reports(pcap_file, gaddr)
 
 
 def test_v2_general_query_response():

--- a/src/test_igmp_manual.py
+++ b/src/test_igmp_manual.py
@@ -25,14 +25,12 @@ def user_input(pytestconfig):
 
     yield suspend_guard()
 
-@pytest.mark.skipif("sys.platform.startswith('linux') or SKIP_MANUAL")
+@pytest.mark.skipif("SKIP_MANUAL")
 def test_report_on_link(user_input):
     """Verify that the device send IGMP membership report on link up
     Although not required by the specification, it can be a good idea to transmit unsolicited
     membership reports on a link up event. This will speed up multicast registrations since now
     the DUT doesn't have to wait on the next query interval.
-
-    This is already an automatic test when the host operating system is a Linux system.
     """
     pcap_file = "output/report_on_link.pcap"
 

--- a/src/test_igmp_v3.py
+++ b/src/test_igmp_v3.py
@@ -5,49 +5,11 @@ IGMPv3 is defined in RFC 3376 (https://datatracker.ietf.org/doc/html/rfc3376)
 The tests in this suite can be skipped by configuring the IGMPv3_SUPPORT parameter
 """
 import pytest
-import warnings
 from time import sleep
 import lib.packet as packet
 from lib.capture import start_capture, stop_capture
-from lib.utils import check_interface_up
-from configuration import IFACE, MGROUP_1, IGMPV3_SUPPORT, IGMP_MEMBERSHIP_REPORT_THRESHOLD
-
-
-def validate_reports(pcap_file, gaddr="0.0.0.0"):
-    """Validate reports
-    This is a helper function to validate if a pcap file contains IGMPv2 or IGMPv3
-    membership reports.
-    """
-    v2_membership_reports = packet.get_v2_membership_reports(pcap_file)
-    v3_membership_reports = packet.get_v3_membership_reports(pcap_file)
-    assert len(v3_membership_reports) > 0 or len(v2_membership_reports) > 0, \
-        "Found no IGMP membership " \
-        "reports, expected at least 1"
-    print(v2_membership_reports)
-    print(v3_membership_reports)
-
-    if len(v3_membership_reports) == 0:
-        warnings.warn(UserWarning("INFO: DUT responded with V2 membership reports to V3 query"))
-
-    print(f"Check that a v3 membership report is received for {MGROUP_1}")
-
-    found_mgroup_1_join = False
-    for report in v2_membership_reports:
-        if report["gaddr"] == MGROUP_1:
-            found_mgroup_1_join = True
-            assert report["gaddr"] == report["dst"], "Membership reports should use the same multicast destination " \
-                                                     "address as the address present in the IGMP payload"
-    for report in v3_membership_reports:
-        assert report["dst"] == "224.0.0.22", "IGMPv3 packets should be addressed to 224.0.0.22"
-        if gaddr != '0.0.0.0':
-            assert len(report["records"]) == 1, 'Specific membership reports are expected to have 1 group record'
-        for record in report["records"]:
-            if record.maddr == MGROUP_1:
-                found_mgroup_1_join = True
-
-    assert found_mgroup_1_join, f"Expected to get an IGMP membership report for multicast group {MGROUP_1}"
-
-    return v2_membership_reports + v3_membership_reports
+from lib.utils import check_interface_up, validate_igmpv3_reports, validate_igmpv3_packet_spacing
+from configuration import IFACE, MGROUP_1, IGMPV3_SUPPORT
 
 
 def validate_membership_reports(
@@ -81,7 +43,7 @@ def validate_membership_reports(
     stop_capture(pcap_file)
 
     print("Check capture for membership report")
-    validate_reports(pcap_file, gaddr)
+    validate_igmpv3_reports(pcap_file, gaddr)
 
 
 @pytest.mark.skipif("not IGMPV3_SUPPORT")
@@ -137,74 +99,29 @@ def test_maximum_response_time():
     Note that in IGMPv3, the maximum response time has an exponential range as described in section 4.1.1 of RFC 3376.
     If the value of the max resp code is above 128 (12.8 seconds), it represents a floating point value.
     """
-    from statistics import variance, median
+    from statistics import variance
     print(f"Detect link up on interface {IFACE}")
     check_interface_up()
 
-    max_response_times = [1, 3, 5, 10, 20, 300]
+    #max_response_times = [1, 3, 5, 10, 20, 300]
+    max_response_times = [20, 300]
     response_times = []
-    for response_time in max_response_times:
-        pcap_file = f"output/v3_maximum_response_time_{response_time}_sec.pcap"
+    for max_response_time in max_response_times:
+        pcap_file = f"output/v3_maximum_response_time_{max_response_time}_sec.pcap"
         print(f"Start capture on interface {IFACE} to file {pcap_file}")
         start_capture(IFACE, pcap_file)
 
-        mrcode = response_time * 10
+        mrcode = max_response_time * 10
         print("Send IGMPv3 membership query")
         packet.send_igmp_v3_membership_query(mrcode=mrcode)
 
         print("Wait for the maximum response time")
-        sleep(response_time + 2)
+        sleep(max_response_time + 2)
 
         print("Stop capture")
         stop_capture(pcap_file)
 
-        print("Check capture for V3 membership report")
-        membership_reports = validate_reports(pcap_file)
-
-        print("Get membership query timestamp")
-        membership_query = packet.get_v3_membership_queries(pcap_file)
-        print(membership_query)
-        assert len(membership_query) == 1, f"Found {len(membership_reports)} IGMPv3 membership " \
-                                           f"queries, expected exactly 1"
-
-        print("Verify for each membership report that it arrived in time")
-        query_time = membership_query[0]["time"]
-        # Add a small tolerance to the maximum response time to take into account
-        # network transit time and timestamp inaccuracy
-        max_resp = response_time + 0.1
-        last_resp = query_time
-        first = True
-        elapsed_list = []
-        for report in membership_reports:
-            # Calculate that the elapsed time since the query packet is within tolerance
-            elapsed = report["time"] - query_time
-            print(f"Got response in {elapsed} seconds. Max is {response_time} seconds")
-            assert elapsed < max_resp, f"Membership report received after {elapsed} seconds, " \
-                                       f"but the maximum is {response_time} seconds"
-            # Only track first response for statistic calculations.
-            # Some devices may have lots of responses, this may disturb the result of the statistics
-            if first:
-                response_times.append(elapsed)
-                first = False
-
-            # Calculate the elapsed time since the previous membership report and verify
-            # That these are not transmitted in a burst
-            elapsed = report["time"] - last_resp
-            last_resp = report["time"]
-            elapsed_list.append(elapsed)
-
-        median_inter_response_time = median(elapsed_list)
-        assert median_inter_response_time > 0.001, \
-            f"The median time between membership responses is {median_inter_response_time}. " \
-            f"This might indicate that responses are transmitted in burst instead of randomly " \
-            f"delaying each and every response. Tranmsitting a lot of IGMP responses in burst may " \
-            f"overload the IGMP querier and cause responses to be dropped, leading to the multicast " \
-            f"registrations being dropped as well."
-
-        assert len(elapsed_list) <= IGMP_MEMBERSHIP_REPORT_THRESHOLD, \
-            f"Received {len(elapsed_list)} membership reports. " \
-            f"There is a limit to the amount of membership reports network equipment can handle. " \
-            f"Verify that all these multicast addresses are necessary for your application."
+        response_times.append(validate_igmpv3_packet_spacing(pcap_file))
 
     var = variance(response_times)
     print(response_times)

--- a/src/test_igmp_v3.py
+++ b/src/test_igmp_v3.py
@@ -10,7 +10,7 @@ from time import sleep
 import lib.packet as packet
 from lib.capture import start_capture, stop_capture
 from lib.utils import check_interface_up
-from configuration import IFACE, MGROUP_1, IGMPV3_SUPPORT
+from configuration import IFACE, MGROUP_1, IGMPV3_SUPPORT, IGMP_MEMBERSHIP_REPORT_THRESHOLD
 
 
 def validate_reports(pcap_file, gaddr="0.0.0.0"):
@@ -137,6 +137,7 @@ def test_maximum_response_time():
     Note that in IGMPv3, the maximum response time has an exponential range as described in section 4.1.1 of RFC 3376.
     If the value of the max resp code is above 128 (12.8 seconds), it represents a floating point value.
     """
+    from statistics import variance, median
     print(f"Detect link up on interface {IFACE}")
     check_interface_up()
 
@@ -171,14 +172,40 @@ def test_maximum_response_time():
         # Add a small tolerance to the maximum response time to take into account
         # network transit time and timestamp inaccuracy
         max_resp = response_time + 0.1
+        last_resp = query_time
+        first = True
+        elapsed_list = []
         for report in membership_reports:
+            # Calculate that the elapsed time since the query packet is within tolerance
             elapsed = report["time"] - query_time
             print(f"Got response in {elapsed} seconds. Max is {response_time} seconds")
             assert elapsed < max_resp, f"Membership report received after {elapsed} seconds, " \
                                        f"but the maximum is {response_time} seconds"
-            response_times.append(elapsed)
+            # Only track first response for statistic calculations.
+            # Some devices may have lots of responses, this may disturb the result of the statistics
+            if first:
+                response_times.append(elapsed)
+                first = False
 
-    from statistics import variance
+            # Calculate the elapsed time since the previous membership report and verify
+            # That these are not transmitted in a burst
+            elapsed = report["time"] - last_resp
+            last_resp = report["time"]
+            elapsed_list.append(elapsed)
+
+        median_inter_response_time = median(elapsed_list)
+        assert median_inter_response_time > 0.001, \
+            f"The median time between membership responses is {median_inter_response_time}. " \
+            f"This might indicate that responses are transmitted in burst instead of randomly " \
+            f"delaying each and every response. Tranmsitting a lot of IGMP responses in burst may " \
+            f"overload the IGMP querier and cause responses to be dropped, leading to the multicast " \
+            f"registrations being dropped as well."
+
+        assert len(elapsed_list) <= IGMP_MEMBERSHIP_REPORT_THRESHOLD, \
+            f"Received {len(elapsed_list)} membership reports. " \
+            f"There is a limit to the amount of membership reports network equipment can handle. " \
+            f"Verify that all these multicast addresses are necessary for your application."
+
     var = variance(response_times)
     print(response_times)
     assert var > 0.2, f"It looks like the membership response times aren't randomly distributed " \

--- a/src/test_pcap.py
+++ b/src/test_pcap.py
@@ -1,0 +1,19 @@
+"""IGMP Pcap Test suite
+The tests in this test suite analyse data from a PCAP network capture instead
+of 'live' connecting to the DUT.
+"""
+import pytest
+from configuration import PCAP_FILE, IGMPV3_SUPPORT
+import lib.utils as utils
+
+@pytest.mark.skipif("not PCAP_FILE")
+def test_pcap_v2():
+    pcap_file = PCAP_FILE
+    utils.validate_igmpv2_reports(pcap_file)
+    utils.validate_igmpv2_packet_spacing(pcap_file)
+
+@pytest.mark.skipif("not PCAP_FILE or not IGMPV3_SUPPORT")
+def test_pcap_v3():
+    pcap_file = PCAP_FILE
+    utils.validate_igmpv3_reports(pcap_file)
+    utils.validate_igmpv3_packet_spacing(pcap_file)


### PR DESCRIPTION
- Detect if the DUT transmits a lot of membership reports
- Detect if the DUT transmits its membership report in 1 burst
- Do the report_on_link test always manually, also on Linux. The result of the automatic link up/down test wasn't stable.
- Don't perform link down detection when executing using docker. The virtual docker interface does not go down.
- Refactoring of the code to allow re-use between IGMPv2 and IGMPv3
- New test suite to check basic IGMP behavior from a capture. Not require direct connection to the DUT.